### PR TITLE
hotfix: return empty list instead of throwing exception when user has no reviews

### DIFF
--- a/MKW/MKW.Services.AppServices/ReviewService.cs
+++ b/MKW/MKW.Services.AppServices/ReviewService.cs
@@ -47,7 +47,12 @@ namespace MKW.Services.AppServices
         {
             var responseDTO = new BaseResponseDTO<ReviewDetailsDto>();
             var review = await _reviewRepository.GetByUserId(userId) ?? throw new NotFoundException("Review not found.");
-            if (!review.Any()) throw new NotFoundException("Review not found.");
+            
+            if (!review.Any())
+            {
+                var reviews = Enumerable.Empty<ReviewDetailsDto>();
+                return responseDTO.AddContent(reviews);
+            }
 
             var reviewDetails = review.Select(x => GetReviewDetails(x, language).Result).Where(x => x.Content != null);
 


### PR DESCRIPTION
# Return empty list instead of throwing exception when user has no reviews

**Affected endpoints**:
- `GET /v1/Review/User/{userId}`

Stop throwing 404 exception when there are no reviews. just return empty list instead.

🔥🐞 


